### PR TITLE
Refactor `update` to avoid isEmpty

### DIFF
--- a/metrics-core/src/main/java/com/codahale/metrics/LockFreeExponentiallyDecayingReservoir.java
+++ b/metrics-core/src/main/java/com/codahale/metrics/LockFreeExponentiallyDecayingReservoir.java
@@ -66,9 +66,7 @@ public final class LockFreeExponentiallyDecayingReservoir implements Reservoir {
             double itemWeight = weight(timestampNanos - startTick);
             double priority = itemWeight / ThreadLocalRandom.current().nextDouble();
             long currentCount = count.get();
-            if (currentCount < size) {
-                addSample(priority, value, itemWeight);
-            } else if (values.firstKey() < priority) {
+            if (currentCount < size || values.firstKey() < priority) {
                 addSample(priority, value, itemWeight);
             }
         }


### PR DESCRIPTION
```
Benchmark                                 (reservoirType)  Mode  Cnt     Score      Error  Units
ReservoirBenchmarks.updateReservoir            EXPO_DECAY  avgt    5  8365.308 ± 1880.683  ns/op
ReservoirBenchmarks.updateReservoir  LOCK_FREE_EXPO_DECAY  avgt    5    73.966 ±    5.305  ns/op
```